### PR TITLE
Add fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 /.pnp
 .pnp.js
 
+# ide
+.idea
+.vscode
+
 # testing
 /coverage
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
+# What has been changed
 
+- `touchmove` event wasn’t cleared on unmount which led to the memory leak;
+- `Input` component was wrapped in a `memo` to avoid rerenders, but `handleBlur` and `handleFocus`  were used without `useCallback` because the cost of re-creating these callbacks on every render is negligible compared to the overhead of `useCallback`;
+- Unnecessary `setTimeout` for `handleFocus` was deleted;
+- inner and outer refs were synchronized with `useImperativeHandle` ;
+- The loader wasn’t working because input could not contain other elements (input::after didn’t render the loader), so a separate div was added for the loader. Also, the UI is not adapted for other types but text, but I guess that’s not what this task is about.
+- Test to cover fixes was written

--- a/src/Input.test.js
+++ b/src/Input.test.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { Input } from './Input';
+
+afterEach(cleanup);
+
+describe('Input Component', () => {
+    test('renders correctly with props', () => {
+        const { container } = render(
+            <Input
+                type="text"
+                loading
+                error={false}
+                placeholder="Enter text"
+            />
+        );
+
+        const inputElement = screen.getByPlaceholderText('Enter text');
+        expect(inputElement).toBeInTheDocument();
+        expect(inputElement).toHaveClass('input');
+        expect(container.querySelector('.loader')).toBeInTheDocument();
+    });
+
+    test('renders loader when `loading` prop is true', () => {
+        render(<Input loading />);
+        expect(screen.getByTestId('loader')).toBeInTheDocument();
+    });
+
+    test('does not render loader when `loading` prop is false', () => {
+        const { container } = render(<Input loading={false} />);
+        expect(container.querySelector('.loader')).not.toBeInTheDocument();
+    });
+
+    test('renders error message when `error` is true', () => {
+        render(<Input error={true} errorMessage="This is an error" />);
+        expect(screen.getByText('This is an error')).toBeInTheDocument();
+    });
+
+    test('focuses and blurs correctly', () => {
+        const handleFocus = jest.fn();
+        const handleBlur = jest.fn();
+
+        render(<Input onFocus={handleFocus} onBlur={handleBlur} />);
+        const inputElement = screen.getByTestId('input');
+
+        fireEvent.focus(inputElement);
+        expect(handleFocus).toHaveBeenCalled();
+
+        fireEvent.blur(inputElement);
+        expect(handleBlur).toHaveBeenCalled();
+    });
+
+    test('calls onChange when typing', () => {
+        const handleChange = jest.fn();
+
+        render(<Input onChange={handleChange} />);
+        const inputElement = screen.getByTestId('input');
+
+        fireEvent.change(inputElement, { target: { value: 'New text' } });
+        expect(handleChange).toHaveBeenCalled();
+        expect(inputElement.value).toBe('New text');
+    });
+
+    test('cleans up touchmove event listener on unmount', () => {
+        const addEventListenerSpy = jest.spyOn(document, 'addEventListener');
+        const removeEventListenerSpy = jest.spyOn(document, 'removeEventListener');
+
+        const { unmount } = render(<Input />);
+        expect(addEventListenerSpy).toHaveBeenCalledWith(
+            'touchmove',
+            expect.any(Function)
+        );
+
+        unmount();
+        expect(removeEventListenerSpy).toHaveBeenCalledWith(
+            'touchmove',
+            expect.any(Function)
+        );
+
+        addEventListenerSpy.mockRestore();
+        removeEventListenerSpy.mockRestore();
+    });
+
+    test('synchronizes inner and outer refs correctly', () => {
+        const ref = React.createRef();
+
+        render(<Input ref={ref} />);
+        expect(ref.current).toBeInstanceOf(HTMLInputElement);
+    });
+
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import Input from './Input';
+import { Input } from './Input';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,3 +1,7 @@
+* {
+  box-sizing: border-box;
+}
+
 .input-wrapper {
   position: relative;
   width: 100%;
@@ -65,7 +69,7 @@
   pointer-events: none;
 }
 
-.input.loading::after {
+.loader {
   content: '';
   position: absolute;
   right: 12px;


### PR DESCRIPTION
- `touchmove` event wasn’t cleared on unmount which led to the memory leak;
- `Input` component was wrapped in a `memo` to avoid rerenders, but `handleBlur` and `handleFocus`  were used without `useCallback` because the cost of re-creating these callbacks on every render is negligible compared to the overhead of `useCallback`;
- Unnecessary `setTimeout` for `handleFocus` was deleted;
- inner and outer refs were synchronized with `useImperativeHandle` ;
- The loader wasn’t working because input could not contain other elements (input::after didn’t render the loader), so a separate div was added for the loader. Also, the UI is not adapted for other types but text, but I guess that’s not what this task is about.
- Test to cover fixes was written